### PR TITLE
Update tool names to be consistent

### DIFF
--- a/llama_agi/agi/tools/NoteTakingTools.py
+++ b/llama_agi/agi/tools/NoteTakingTools.py
@@ -5,7 +5,7 @@ from agi.utils import initialize_search_index
 note_index = initialize_search_index([])
 
 
-@tool
+@tool("Record Note")
 def record_note(note: str) -> str:
     """Useful for when you need to record a note or reminder for yourself to reference in the future."""
     global note_index
@@ -13,7 +13,7 @@ def record_note(note: str) -> str:
     return "Note successfully recorded."
 
 
-@tool
+@tool("Search Notes")
 def search_notes(query_str: str) -> str:
     """Useful for searching through notes that you previously recorded."""
     global note_index

--- a/llama_agi/agi/tools/WebpageSearchTool.py
+++ b/llama_agi/agi/tools/WebpageSearchTool.py
@@ -6,7 +6,7 @@ from agi.utils import initialize_search_index
 BeautifulSoupWebReader = download_loader("BeautifulSoupWebReader")
 
 
-@tool
+@tool("Search Webpage")
 def search_webpage(prompt: str) -> str:
     """Useful for searching a specific webpage. The input to the tool should be URL and query, separated by a newline."""
     loader = BeautifulSoupWebReader()


### PR DESCRIPTION
I noticed in your tweet @jerryjliu that the agent made a mistake in the tool name haha https://twitter.com/jerryjliu0/status/1648347966615465984/photo/1

This is probably because the default tool names use normal uppercase names, while the custom tools were using the function names with underscores as tool names

To limit the confusion, we can set the tool names to all be in a similar format