### PR TITLE
[llama_agi] Improve task parsing

### DIFF
--- a/llama_agi/agi/TaskManager.py
+++ b/llama_agi/agi/TaskManager.py
@@ -59,10 +59,10 @@ class TaskManager:
         # Try to parse lists with json, fallback to regex
         new_tasks: List[str] = []
         try:
-            new_tasks = json.loads(str(new_tasks))
+            new_tasks = json.loads(task_list_str)
             new_tasks = [x.strip() for x in new_tasks if len(x.strip()) > 10]
         except Exception:
-            new_tasks = str(new_tasks).split("\n")
+            new_tasks = str(task_list_str).split("\n")
             new_tasks = [
                 re.sub(r"^[0-9]+\.", "", x).strip()
                 for x in str(new_tasks)

--- a/llama_agi/run_llama_agi.py
+++ b/llama_agi/run_llama_agi.py
@@ -20,7 +20,7 @@ def run_llama_agi(objective: str, initial_task: str, sleep_time: int) -> None:
     initial_task_list_str = simple_execution_agent.execute_task(
         objective, initial_task_prompt, initial_completed_tasks_summary
     )
-    initial_task_list = json.loads(initial_task_list_str)
+    initial_task_list = task_manager.parse_task_list(initial_task_list_str)
 
     # add tasks to the task manager
     task_manager.add_new_tasks(initial_task_list)

--- a/llama_agi/run_llama_agi.py
+++ b/llama_agi/run_llama_agi.py
@@ -28,12 +28,10 @@ def run_llama_agi(objective: str, initial_task: str, sleep_time: int) -> None:
     # prioritize initial tasks
     task_manager.prioritize_tasks(objective)
 
+    completed_tasks_summary = initial_completed_tasks_summary
     while True:
         # Get the next task
         cur_task = task_manager.get_next_task()
-
-        # Summarize completed tasks
-        completed_tasks_summary = task_manager.get_completed_tasks_summary()
 
         # Execute current task
         result = tool_execution_agent.execute_task(
@@ -45,6 +43,9 @@ def run_llama_agi(objective: str, initial_task: str, sleep_time: int) -> None:
 
         # generate new task(s), if needed
         task_manager.generate_new_tasks(objective, cur_task, result)
+
+        # Summarize completed tasks
+        completed_tasks_summary = task_manager.get_completed_tasks_summary()
 
         # log state of AGI to terminal
         log_current_status(


### PR DESCRIPTION
This should fix https://github.com/run-llama/llama-lab/issues/13 -> adds a unified function for parsing the task lists generated by the LLM

Also, a minor tweak to when the complete_tasks_summary is generated in the loop